### PR TITLE
Enable dynamic DICOM column selection with dry-run preview

### DIFF
--- a/dicom_anonymizer/application/anonymizer_utils/anonymize_dicom.py
+++ b/dicom_anonymizer/application/anonymizer_utils/anonymize_dicom.py
@@ -135,8 +135,10 @@ def consolidate_tags(row: pd.Series, update_tags: dict) -> dict:
     
     update = {}
     for dcm_tag in update_tags:
-        update[tag_dict[dcm_tag]] = row[f'Update_{dcm_tag}']
-    
+        value = row.get(f'Update_{dcm_tag}')
+        if pd.notna(value) and value != '':
+            update[tag_dict[dcm_tag]] = value
+
     return update
 
 def remove_info(dataset: Dataset,

--- a/dicom_anonymizer/application/app_settings/config.py
+++ b/dicom_anonymizer/application/app_settings/config.py
@@ -7,8 +7,8 @@ unique_ids = [
     'AccessionNumber'
 ]
 
-# DICOM tags: to be Shown in template for user's reference (list)
-ref_tags = [
+# DICOM tags: available to be shown in template for user's reference (list)
+ref_tag_options = [
     'PatientBirthDate',
     'PatientSex',
     'PatientAge',
@@ -17,8 +17,8 @@ ref_tags = [
     'BodyPartExamined'
 ]
 
-# DICOM tags: to be Anonymized default values or user's inputs (dict)
-update_tags = {
+# DICOM tags: available to be anonymized with default values or user's inputs (dict)
+update_tag_defaults = {
     'PatientName':      '',                                     # for user's inputs
     'PatientID':        '',                                     # for user's inputs
     'BodyPartExamined': ''
@@ -38,11 +38,11 @@ series_unique_ids = [
     'SeriesInstanceUID'
 ]
 
-# DICOM tags: to be Shown in template for user's reference at series level (list)
-series_ref_tags = ref_tags + ['SeriesInstanceUID']
+# DICOM tags: available to be shown in template for user's reference at series level (list)
+series_ref_tag_options = ref_tag_options + ['SeriesInstanceUID']
 
-# DICOM tags: to be Anonymized default values or user's inputs at series level (dict)
-series_update_tags = update_tags | {
+# DICOM tags: available to be anonymized default values or user's inputs at series level (dict)
+series_update_tag_defaults = update_tag_defaults | {
     'SeriesDescription': ''
 }
 


### PR DESCRIPTION
## Summary
- allow selecting displayed and updatable DICOM tags via Streamlit multiselect widgets
- support optional updates: blank `Update_` fields leave original values unchanged
- show a highlighted dry-run of edits before anonymization and run updates only on request

## Testing
- `python -m py_compile dicom_anonymizer/application/app_settings/config.py dicom_anonymizer/application/user_interface.py dicom_anonymizer/application/ui_utils/ui_logic.py dicom_anonymizer/application/anonymizer_utils/anonymize_dicom.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed373e60832f9debdc9e58a8a37d