### PR TITLE
Enable dynamic DICOM column selection with dry-run preview

### DIFF
--- a/dicom_anonymizer/.streamlit/config.toml
+++ b/dicom_anonymizer/.streamlit/config.toml
@@ -4,10 +4,8 @@ developmentMode = true
 
 [server]
 port = 8502
+enableXsrfProtection = false
+enableCORS = false
 
 [client]
 showErrorDetails = true
-
-[server]
-enableXsrfProtection = false
-enableCORS = false

--- a/dicom_anonymizer/__init__.py
+++ b/dicom_anonymizer/__init__.py
@@ -1,0 +1,1 @@
+"""dicom_anonymizer package"""

--- a/dicom_anonymizer/application/app_settings/config.py
+++ b/dicom_anonymizer/application/app_settings/config.py
@@ -7,8 +7,8 @@ unique_ids = [
     'AccessionNumber'
 ]
 
-# DICOM tags: to be Shown in template for user's reference (list)
-ref_tags = [
+# DICOM tags: available to be shown in template for user's reference (list)
+ref_tag_options = [
     'PatientBirthDate',
     'PatientSex',
     'PatientAge',
@@ -17,8 +17,8 @@ ref_tags = [
     'BodyPartExamined'
 ]
 
-# DICOM tags: to be Anonymized default values or user's inputs (dict)
-update_tags = {
+# DICOM tags: available to be anonymized with default values or user's inputs (dict)
+update_tag_defaults = {
     'PatientName':      '',                                     # for user's inputs
     'PatientID':        '',                                     # for user's inputs
     'BodyPartExamined': ''
@@ -38,11 +38,11 @@ series_unique_ids = [
     'SeriesInstanceUID'
 ]
 
-# DICOM tags: to be Shown in template for user's reference at series level (list)
-series_ref_tags = ref_tags + ['SeriesInstanceUID']
+# DICOM tags: available to be shown in template for user's reference at series level (list)
+series_ref_tag_options = ref_tag_options + ['SeriesInstanceUID']
 
-# DICOM tags: to be Anonymized default values or user's inputs at series level (dict)
-series_update_tags = update_tags | {
+# DICOM tags: available to be anonymized default values or user's inputs at series level (dict)
+series_update_tag_defaults = update_tag_defaults | {
     'SeriesDescription': ''
 }
 
@@ -54,6 +54,4 @@ tags_2_anon = None
 tags_2_spare = []
 
 # DICOM tags: to be Created (dict: 'TagName': (options))
-new_tags = {
-    'BodyPartExamined': ('Head', 'Thorax', 'Chest'),
-}
+new_tags = {}

--- a/dicom_anonymizer/application/user_interface.py
+++ b/dicom_anonymizer/application/user_interface.py
@@ -1,21 +1,22 @@
 import streamlit as st
 import json
 import pandas as pd
+from pathlib import Path
 
 from anonymizer_utils.anonymize_dicom import *
 from ui_utils.ui_logic import *
 from app_settings.config import (
     unique_ids,
-    ref_tags,
-    update_tags,
+    ref_tag_options,
+    update_tag_defaults,
     upload_df_id,
     series_upload_df_id,
     tags_2_anon,
     tags_2_spare,
     new_tags,
     series_unique_ids,
-    series_ref_tags,
-    series_update_tags,
+    series_ref_tag_options,
+    series_update_tag_defaults,
 )
 
 def streamlit_app(): 
@@ -40,6 +41,10 @@ def streamlit_app():
         st.session_state['series_mode'] = False
     if 'matcher_id' not in st.session_state:        # identifier column in templates
         st.session_state['matcher_id'] = upload_df_id
+    if 'selected_display_tags' not in st.session_state:
+        st.session_state['selected_display_tags'] = []
+    if 'selected_update_tags' not in st.session_state:
+        st.session_state['selected_update_tags'] = []
 
     # Page user interface
     st.set_page_config(page_title = 'DICOM Anonymizer')
@@ -54,12 +59,15 @@ def streamlit_app():
 
     user_fformat = st.text_input(
         'File extension',
-        placeholder='e.g., "dcm"'
+        placeholder='e.g., "*.dcm"', 
+        value='*.dcm'
     )
 
     series_mode_box = st.checkbox("Anonymize per series", value=st.session_state['series_mode'])
     if series_mode_box != st.session_state['series_mode']:
         st.session_state['dcm_info'] = None
+        st.session_state['selected_display_tags'] = []
+        st.session_state['selected_update_tags'] = []
     st.session_state['series_mode'] = series_mode_box
 
     if st.session_state['series_mode']:
@@ -68,8 +76,8 @@ def streamlit_app():
         st.session_state['matcher_id'] = upload_df_id
 
     active_unique_ids = series_unique_ids if st.session_state['series_mode'] else unique_ids
-    active_ref_tags = series_ref_tags if st.session_state['series_mode'] else ref_tags
-    active_update_tags = series_update_tags if st.session_state['series_mode'] else update_tags
+    ref_options = series_ref_tag_options if st.session_state['series_mode'] else ref_tag_options
+    update_options = series_update_tag_defaults if st.session_state['series_mode'] else update_tag_defaults
     active_upload_df_id = st.session_state['matcher_id']
 
     # A container of user instruction
@@ -82,7 +90,7 @@ def streamlit_app():
 
             ### Modification of DICOM Tag values
             - :red[Update Input Template]: Update your inputs using the automatically generated template. If you prefer to use your own template, please ensure that you include the column "{active_upload_df_id}" as an identifier for the cases.
-            - :red[Avoid Empty Fields]: When uploading the updated template, ensure that there are NO empty inputs in the columns that start with "Update" (e.g. `Update_PatientName`). The values under these columns will be directly applied to the anonymized files.
+            - :red[Optional Updates]: The template contains columns starting with "Update" (e.g. `Update_PatientName`). Leave a field blank if you do not wish to modify that value.
             - :red[Default values]: You can modify the following DICOM tags. For your convenience, default values have been pre-set for certain tags to streamline the anonymization process.
 
             | DICOM Tag           | Default value     |
@@ -125,22 +133,20 @@ def streamlit_app():
     # Feed user inputted folder dir and file extension to fetch files
     else: 
         with st.spinner(text='Fetching files...'):
+            progress_bar = st.progress(0, text="Initiating read...")
             try:
+                all_ref_tags = list(dict.fromkeys(ref_options + list(update_options.keys())))
                 st.session_state['dcm_info'] = create_dcm_df(
                     folder=st.session_state['folder'],
                     fformat=st.session_state['fformat'],
                     unique_ids=active_unique_ids,
-                    ref_tags=active_ref_tags,
+                    ref_tags=all_ref_tags,
                     new_tags=list(new_tags.keys()),
-                    series_mode=st.session_state['series_mode']
+                    series_mode=st.session_state['series_mode'], 
+                    progress_bar=progress_bar
                 )
-                display_cols = list(dict.fromkeys(active_unique_ids + active_ref_tags))
-                uids_df = st.session_state['dcm_info'][display_cols]
-                if not st.session_state['series_mode']:
-                    uids_df = uids_df.drop_duplicates()
-                st.session_state['uids'] = uids_df
             except Exception as e:
-                st.error(':warning: We cannot find any files in the file extension in the directory.')
+                st.error(f':warning: We cannot find any files in the file extension in the directory.\nOriginal error: {e}')
                 st.logger.get_logger('ui').exception(e)
 
     # When fetch file function is not triggered, display nothing
@@ -149,19 +155,42 @@ def streamlit_app():
 
     # When files are found, display unique ID df
     else:
-        if (not st.session_state['series_mode'] and
-                st.session_state['dcm_info'][upload_df_id].isnull().any()):
-            st.warning(':warning: Some DICOM files are missing AccessionNumber. Please select a matcher column.')
-            options = [col for col in [upload_df_id, 'PatientID', 'SeriesInstanceUID', 'SOPInstanceUID']
-                       if col in st.session_state['dcm_info'].columns]
-            st.session_state['matcher_id'] = st.selectbox(
-                'Select matcher column',
-                options,
-                index=options.index(st.session_state['matcher_id']) if st.session_state['matcher_id'] in options else 0,
-            )
+        options = [col for col in active_unique_ids if col in st.session_state['dcm_info'].columns]
+        st.session_state['matcher_id'] = st.selectbox(
+            'Select matcher column',
+            options,
+            index=options.index(st.session_state['matcher_id']) if st.session_state['matcher_id'] in options else 0,
+        )
         active_upload_df_id = st.session_state['matcher_id']
+        if st.session_state['dcm_info'][active_upload_df_id].isnull().any():
+            st.warning(':warning: Some DICOM files are missing the selected matcher column.')
 
-        edit_df = create_update_cols(st.session_state['uids'], active_update_tags)
+        if not st.session_state['selected_display_tags']:
+            st.session_state['selected_display_tags'] = ref_options
+        if not st.session_state['selected_update_tags']:
+            st.session_state['selected_update_tags'] = list(update_options.keys())
+
+        st.session_state['selected_display_tags'] = st.multiselect(
+            'Select columns to display',
+            ref_options,
+            default=st.session_state['selected_display_tags']
+        )
+        st.session_state['selected_update_tags'] = st.multiselect(
+            'Select columns to update',
+            list(update_options.keys()),
+            default=st.session_state['selected_update_tags']
+        )
+
+        active_ref_tags = st.session_state['selected_display_tags']
+        active_update_tags = {k: update_options[k] for k in st.session_state['selected_update_tags']}
+
+        display_cols = list(dict.fromkeys(active_unique_ids + active_ref_tags + list(active_update_tags.keys())))
+        uids_df = st.session_state['dcm_info'][display_cols]
+        if not st.session_state['series_mode']:
+            uids_df = uids_df.loc[~uids_df.index.duplicated()]
+        st.session_state['uids'] = uids_df
+
+        edit_df = create_update_cols(st.session_state['uids'].copy(), active_update_tags)
         st.session_state['edit_df'] = edit_df
 
         case_desc = 'unique series' if st.session_state['series_mode'] else 'unique cases'
@@ -235,9 +264,10 @@ def streamlit_app():
         # Save latest version of edit_df to session state
         st.session_state['edit_df'] = edit_df
         
+        styled_df = highlight_updated_cells(st.session_state['edit_df'], active_update_tags)
         display_data.dataframe(
-            st.session_state['edit_df'], 
-            use_container_width=True, 
+            styled_df,
+            use_container_width=True,
             hide_index=True
         )
 
@@ -264,7 +294,7 @@ def streamlit_app():
                 tags_2_create[dcm_tag] = create_new_tag.selectbox(f'Please select a value for DICOM Tag: `{dcm_tag}`.', options)
         
         # Capture user's input to write anonymized files 
-        if st.button("Anonymize files", type='primary'): 
+        if st.button("Run", type='primary'):
             if upload_file is None: 
                 st.warning(':warning: Please upload a file as your inputs before file anonymization.')
             else:

--- a/dicom_anonymizer/requirements.txt
+++ b/dicom_anonymizer/requirements.txt
@@ -1,0 +1,17 @@
+# Core dependencies
+pandas>=2.2.3
+pydicom>=3.0.1
+streamlit>=1.29.0
+
+# Testing dependencies
+pytest>=7.0.0
+
+# Build dependencies (optional - for creating executables)
+pyinstaller<=5.10.0
+
+# Standard library dependencies (included for completeness)
+# pathlib - part of Python standard library (3.4+)
+# typing - part of Python standard library (3.5+)
+# json - part of Python standard library
+# re - part of Python standard library
+# os - part of Python standard library

--- a/dicom_anonymizer/run_app.py
+++ b/dicom_anonymizer/run_app.py
@@ -1,7 +1,73 @@
 import os
+from typing import cast
+from streamlit import logger
+import logging
 import streamlit.web.bootstrap
+from rich.logging import RichHandler
+
+# Inject rich handler as formatter
+def setup_formatter(logger: logging.Logger) -> None:
+    """Set up the console formatter for a given logger."""
+    # Deregister any previous console loggers.
+    for hdlr in logger.handlers:
+        logger.removeHandler(hdlr)
+    logger.streamlit_console_handler = RichHandler(rich_tracebacks=True, tracebacks_show_locals=True)  # type: ignore[attr-defined]
+
+    # Import here to avoid circular imports
+    from streamlit import config
+
+    if config._config_options:
+        # logger is required in ConfigOption.set_value
+        # Getting the config option before the config file has been parsed
+        # can create an infinite loop
+        message_format = config.get_option("logger.messageFormat")
+    else:
+        message_format = None
+        
+    formatter = logging.Formatter(fmt=message_format)
+    formatter.default_msec_format = "%s.%03d"
+    logger.streamlit_console_handler.setFormatter(formatter)  # type: ignore[attr-defined]
+
+    # Register the new console logger.
+    logger.addHandler(logger.streamlit_console_handler)  # type: ignore[attr-defined]        
+# Inject it
+logger.setup_formatter = setup_formatter
+
+from rich.logging import RichHandler
+
+# Inject rich handler as formatter
+def setup_formatter(logger: logging.Logger) -> None:
+    """Set up the console formatter for a given logger."""
+    # Deregister any previous console loggers.
+    for hdlr in logger.handlers:
+        logger.removeHandler(hdlr)
+    logger.streamlit_console_handler = RichHandler(rich_tracebacks=True, tracebacks_show_locals=True)  # type: ignore[attr-defined]
+
+    # Import here to avoid circular imports
+    from streamlit import config
+
+    if config._config_options:
+        # logger is required in ConfigOption.set_value
+        # Getting the config option before the config file has been parsed
+        # can create an infinite loop
+        message_format = config.get_option("logger.messageFormat")
+    else:
+        message_format = None
+        
+    formatter = logging.Formatter(fmt=message_format)
+    formatter.default_msec_format = "%s.%03d"
+    logger.streamlit_console_handler.setFormatter(formatter)  # type: ignore[attr-defined]
+
+    # Register the new console logger.
+    logger.addHandler(logger.streamlit_console_handler)  # type: ignore[attr-defined]        
+# Inject it
+logger.setup_formatter = setup_formatter
+
 
 if __name__ == "__main__":
+    st_logger = logger.get_logger("anonymizer")
+    st_logger.info("Initiating DicomAnonymizer")
+    logger.set_log_level('DEBUG')
     os.chdir(os.path.dirname(__file__))
 
     flag_options = {
@@ -13,7 +79,9 @@ if __name__ == "__main__":
     flag_options["_is_running_with_streamlit"] = True
     streamlit.web.bootstrap.run(
         "./application/DicomAnonymizer.py",
-        "streamlit run",
+        False,
+        False,
         [],
-        flag_options,
+        flag_options
+        flag_options
     )

--- a/dicom_anonymizer/tests/test_anonymize_dicom.py
+++ b/dicom_anonymizer/tests/test_anonymize_dicom.py
@@ -1,0 +1,125 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pandas as pd
+import numpy as np
+from pydicom.dataset import Dataset, FileDataset
+from pydicom.uid import ExplicitVRLittleEndian, generate_uid
+from pydicom.tag import Tag
+import pydicom
+
+from dicom_anonymizer.application.anonymizer_utils.anonymize_dicom import (
+    create_output_dir,
+    create_dcm_df,
+    consolidate_tags,
+    remove_info,
+    anonymize,
+)
+
+
+def _create_test_dicom(path: Path, patient_name: str = "John", patient_id: str = "12345") -> Path:
+    """Create a minimal DICOM file for testing."""
+    file_meta = Dataset()
+    file_meta.MediaStorageSOPClassUID = generate_uid()
+    file_meta.MediaStorageSOPInstanceUID = generate_uid()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+
+    ds = FileDataset(str(path), {}, file_meta=file_meta, preamble=b"\0" * 128)
+    ds.SOPClassUID = file_meta.MediaStorageSOPClassUID
+    ds.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+    ds.PatientName = patient_name
+    ds.PatientID = patient_id
+    ds.PatientBirthDate = "19700101"
+    ds.PatientSex = "M"
+    ds.StudyDate = "20210101"
+    ds.Modality = "OT"
+    ds.SeriesInstanceUID = generate_uid()
+    ds.StudyInstanceUID = generate_uid()
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+    ds.Rows = 1
+    ds.Columns = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+    ds.SamplesPerPixel = 1
+    ds.BitsAllocated = 16
+    ds.BitsStored = 16
+    ds.HighBit = 15
+    ds.PixelRepresentation = 0
+    ds.PixelData = b"\0\0"
+    ds.save_as(path)
+    return path
+
+
+def test_create_output_dir(tmp_path):
+    folder_dir = tmp_path / "dataset"
+    sub_folder = folder_dir / "patient1"
+    expected = tmp_path / "dataset-Anonymized" / "patient1"
+    result = create_output_dir(sub_folder, folder_dir)
+    assert result == str(expected)
+
+
+def test_create_dcm_df(tmp_path):
+    base = tmp_path / "data"
+    patient_folder = base / "p1"
+    patient_folder.mkdir(parents=True)
+    _create_test_dicom(patient_folder / "img.dcm")
+
+    df = create_dcm_df(
+        folder=str(base),
+        fformat="dcm",
+        unique_ids=["PatientID"],
+        ref_tags=["PatientID", "PatientName"],
+        new_tags=["StudyDate"],
+    )
+
+    assert list(df.index) == ["12345"]
+    assert df.loc["12345", "PatientName"] == "John"
+    expected_out = create_output_dir(patient_folder, base)
+    assert df.loc["12345", "output_dir"] == expected_out
+    assert set(["folder_dir", "output_dir", "PatientID", "PatientName", "StudyDate"]).issubset(df.columns)
+
+
+def test_consolidate_tags():
+    row = pd.Series({"Update_PatientName": "Anon", "Update_PatientID": "999"})
+    update_tags = {"PatientName": None, "PatientID": None}
+    result = consolidate_tags(row, update_tags)
+    assert result[Tag((0x0010, 0x0010))] == "Anon"
+    assert result[Tag((0x0010, 0x0020))] == "999"
+
+
+def test_remove_info():
+    ds = Dataset()
+    ds.PatientName = "John"
+    ds.AccessionNumber = "ACC"
+    ds.PatientID = "123"
+
+    remove_info(ds, ds["PatientName"], va_type=None, tags=[], update=None, tags_2_spare=[])
+    assert ds.PatientName == "Anonymized"
+
+    remove_info(ds, ds["AccessionNumber"], va_type=None, tags=[Tag((0x0008, 0x0050))], update=None, tags_2_spare=[])
+    assert ds.AccessionNumber == ""
+
+    remove_info(ds, ds["PatientID"], va_type=None, tags=[], update={Tag((0x0010, 0x0020)): "NEW"}, tags_2_spare=[])
+    assert ds.PatientID == "NEW"
+
+
+def test_anonymize(tmp_path):
+    src = tmp_path / "in.dcm"
+    dst = tmp_path / "out" / "anon.dcm"
+    dst.parent.mkdir()
+    _create_test_dicom(src)
+
+    update = {Tag((0x0010, 0x0010)): "Anon"}
+    spare = [Tag((0x0010, 0x0020))]
+    create = {"BodyPartExamined": "CHEST"}
+
+    anonymize(str(src), str(dst), update=update, tags_2_spare=spare, tags_2_create=create)
+
+    out = pydicom.dcmread(str(dst))
+    assert out.PatientName == "Anon"
+    assert out.PatientID == "12345"  # spared
+    assert out.BodyPartExamined == "CHEST"
+    assert out.PatientBirthDate == ""

--- a/dicom_anonymizer/tests/test_ui_logic.py
+++ b/dicom_anonymizer/tests/test_ui_logic.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import pandas as pd
+
+from dicom_anonymizer.application.ui_utils.ui_logic import (
+    create_update_cols,
+    update_data_editor,
+)
+
+
+def test_create_update_cols():
+    df = pd.DataFrame({"PatientName": ["Alice"], "PatientID": ["1"]})
+    update_tags = {"PatientName": lambda x: x.upper(), "PatientID": "anon"}
+    out = create_update_cols(df, update_tags)
+    assert out["Update_PatientName"].tolist() == ["ALICE"]
+    assert out["Update_PatientID"].tolist() == ["anon"]
+
+
+def test_update_data_editor():
+    edit_df = pd.DataFrame({
+        "PatientID": ["1", "2"],
+        "PatientName": ["Alice", "Bob"],
+    })
+    update_tags = {"PatientName": "", "PatientID": ""}
+    edit_df = create_update_cols(edit_df, update_tags)
+
+    upload_df = pd.DataFrame({
+        "PatientID": ["1"],
+        "Update_PatientName": ["ANN"],
+        "Update_PatientID": ["99"],
+    })
+
+    result = update_data_editor(edit_df, upload_df, update_tags, ["PatientID"])
+    row1 = result[result["PatientID"] == "1"].iloc[0]
+    row2 = result[result["PatientID"] == "2"].iloc[0]
+    assert row1["Update_PatientName"] == "ANN"
+    assert row1["Update_PatientID"] == "99"
+    assert row2["Update_PatientName"] == ""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = dicom_anonymizer/tests


### PR DESCRIPTION
## Summary
- allow selecting displayed and updatable DICOM tags via Streamlit multiselect widgets
- support optional updates: blank `Update_` fields leave original values unchanged
- show a highlighted dry-run of edits before anonymization and run updates only on request
- let users choose the matcher column rather than being locked to AccessionNumber
- fix anonymizer utilities so Run button executes and handles flexible file patterns

## Testing
- `python -m py_compile dicom_anonymizer/application/app_settings/config.py dicom_anonymizer/application/user_interface.py dicom_anonymizer/application/ui_utils/ui_logic.py dicom_anonymizer/application/anonymizer_utils/anonymize_dicom.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed373e60832f9debdc9e58a8a37d