### PR TITLE
Add standalone DICOM X-Ray anonymizer CLI tool

### DIFF
--- a/dicom_anonymizer_2/README.md
+++ b/dicom_anonymizer_2/README.md
@@ -1,0 +1,237 @@
+# DICOM X-Ray Anonymizer
+
+A standalone Python script for anonymizing X-Ray DICOM files with series-based Scan ID assignment. This tool implements a chronology-based anonymization strategy where each scan series per patient receives a unique identifier assigned to the `AccessionNumber` field.
+
+## Overview
+
+This anonymizer processes DICOM files by:
+1. Discovering all DICOM files recursively in a directory
+2. Extracting metadata (patient info, study details, series info)
+3. Generating Scan IDs based on scan chronology per patient
+4. Assigning Scan IDs to the `AccessionNumber` field
+5. Saving both original and anonymized metadata to CSV files
+6. Optionally writing anonymized DICOM files to an output directory
+
+## Key Features
+
+- **Series-Based Anonymization**: Each unique series per patient gets a distinct Scan ID
+- **Chronological Ordering**: Scan IDs are assigned based on StudyDate and StudyTime
+- **Suffix System**: Uses a printable ASCII suffix sequence (first scan: no suffix, then A-Z, then symbols)
+- **Metadata Export**: Generates CSV files with both original and anonymized metadata
+- **CSV-Only Mode**: Option to generate metadata without modifying DICOM files
+- **Preserves Directory Structure**: Maintains relative paths in the output directory
+
+## Anonymization Logic
+
+### Scan ID Generation
+
+The script assigns a Scan ID (stored in `AccessionNumber`) to each series using this logic:
+
+1. **Group by Patient**: All files are grouped by `PatientID`
+2. **Identify Series**: Within each patient, unique series are identified by `SeriesInstanceUID`
+3. **Sort Chronologically**: Series are sorted by `StudyDate` then `StudyTime` (ascending)
+4. **Assign Suffixes**:
+   - **First series**: Scan ID = `PatientID` (no suffix)
+   - **Second series**: Scan ID = `PatientID` + "A"
+   - **Third series**: Scan ID = `PatientID` + "B"
+   - **And so on...**
+5. **Apply to All Files**: All DICOM files within the same series receive the same Scan ID
+
+### Suffix Sequence
+
+The suffix sequence follows this order (86 total suffixes):
+- Empty string (first scan)
+- Uppercase letters: A-Z (26 characters)
+- Symbols and digits: `!"#$%&'()*+,-./0-9:;<=>?@[\]^_{|}~` (59 characters)
+
+If a patient has more than 86 series, the suffix format switches to `_scanN`.
+
+## Installation
+
+### Requirements
+
+- Python 3.9+
+- Dependencies:
+  ```bash
+  pip install pydicom pandas
+  ```
+
+### Using uv (Recommended)
+
+If using `uv` package manager:
+```bash
+uv sync
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+python anonymizer_rename.py \
+    --input-dir /path/to/xray/data \
+    --output-csv-original /path/to/original_metadata.csv \
+    --output-csv-anon /path/to/anonymized_metadata.csv
+```
+
+This will:
+- Read DICOM files from `/path/to/xray/data`
+- Create anonymized DICOM files in `/path/to/xray/data-Anonymized`
+- Save original metadata to `original_metadata.csv`
+- Save anonymized metadata to `anonymized_metadata.csv`
+
+### CSV-Only Mode
+
+To generate metadata without modifying DICOM files:
+
+```bash
+python anonymizer_rename.py \
+    --input-dir /path/to/xray/data \
+    --output-csv-original original.csv \
+    --output-csv-anon anonymized.csv \
+    --csv-only
+```
+
+### Custom Output Directory
+
+Specify a custom output directory for anonymized DICOM files:
+
+```bash
+python anonymizer_rename.py \
+    --input-dir /path/to/xray/data \
+    --output-csv-original original.csv \
+    --output-csv-anon anonymized.csv \
+    --output-dir /custom/output/path
+```
+
+### Verbose Logging
+
+Enable detailed logging for debugging:
+
+```bash
+python anonymizer_rename.py \
+    --input-dir /path/to/xray/data \
+    --output-csv-original original.csv \
+    --output-csv-anon anonymized.csv \
+    --verbose
+```
+
+## Command-Line Options
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--input-dir` | Yes | Root directory containing DICOM files |
+| `--output-csv-original` | Yes | Path for original metadata CSV output |
+| `--output-csv-anon` | Yes | Path for anonymized metadata CSV output |
+| `--output-dir` | No | Custom output directory (default: `<input-dir>-Anonymized`) |
+| `--csv-only` | No | Only generate CSV files without modifying DICOM files |
+| `--verbose` | No | Enable verbose logging (DEBUG level) |
+
+## Output Structure
+
+### Anonymized DICOM Files
+
+By default, anonymized files are saved to a sibling directory:
+```
+/path/to/xray/data/              # Input directory
+/path/to/xray/data-Anonymized/   # Output directory (created automatically)
+```
+
+The directory structure is preserved:
+```
+Input:
+  /path/to/xray/data/patient1/series1/image001.dcm
+
+Output:
+  /path/to/xray/data-Anonymized/patient1/series1/image001.dcm
+```
+
+### CSV Metadata Files
+
+Both CSV files contain the following columns:
+
+#### Original Metadata CSV
+- `PatientName`
+- `PatientID`
+- `PatientBirthDate`
+- `PatientSex`
+- `AccessionNumber` (original)
+- `InstitutionName`
+- `StudyDate`
+- `StudyTime`
+- `SeriesInstanceUID`
+- `BodyPartExamined`
+
+#### Anonymized Metadata CSV
+Same columns as above, but `AccessionNumber` is replaced with the anonymized Scan ID.
+
+## Example
+
+Given a patient with ID `P001` who has 3 X-ray series taken on different dates:
+
+| Series | StudyDate | Original AccessionNumber | New AccessionNumber (Scan ID) |
+|--------|-----------|-------------------------|------------------------------|
+| Series 1 | 2025-01-10 | ACC001 | `P001` |
+| Series 2 | 2025-01-15 | ACC002 | `P001A` |
+| Series 3 | 2025-01-20 | ACC003 | `P001B` |
+
+All DICOM files within Series 1 will have `AccessionNumber = "P001"`, all files in Series 2 will have `AccessionNumber = "P001A"`, and so on.
+
+## Extracted DICOM Tags
+
+The script extracts the following DICOM tags:
+
+| Tag Name | Tag ID | Description |
+|----------|--------|-------------|
+| PatientName | (0x0010, 0x0010) | Patient's full name |
+| PatientID | (0x0010, 0x0020) | Primary patient identifier |
+| PatientBirthDate | (0x0010, 0x0030) | Patient's birth date |
+| PatientSex | (0x0010, 0x0040) | Patient's sex |
+| AccessionNumber | (0x0008, 0x0050) | Study accession number (modified during anonymization) |
+| InstitutionName | (0x0008, 0x0080) | Institution name |
+| StudyDate | (0x0008, 0x0020) | Study date |
+| StudyTime | (0x0008, 0x0031) | Study time |
+| SeriesInstanceUID | (0x0020, 0x000e) | Unique series identifier |
+| BodyPartExamined | (0x0018, 0x0015) | Body part examined |
+
+## Logging
+
+The script provides informative logging at two levels:
+
+- **INFO** (default): Progress updates, statistics, and summary
+- **DEBUG** (`--verbose`): Detailed file-by-file processing information
+
+Example output:
+```
+2025-01-20 14:30:00 - INFO - Searching for DICOM files in: /path/to/data
+2025-01-20 14:30:02 - INFO - Found 150 DICOM files
+2025-01-20 14:30:05 - INFO - Successfully processed 150/150 files
+2025-01-20 14:30:05 - INFO - Generated anonymized names for 25 patients
+2025-01-20 14:30:10 - INFO - Anonymization complete: 150 successful, 0 failed
+```
+
+## Error Handling
+
+The script handles common errors gracefully:
+
+- **Invalid DICOM files**: Logged as warnings, processing continues
+- **Missing metadata**: Missing tags are stored as `None`
+- **File I/O errors**: Logged with detailed error messages
+- **Missing directories**: Input directory validation before processing
+
+## Limitations
+
+- Only processes files with `.dcm` extension
+- Requires `SeriesInstanceUID` for series-based grouping
+- Maximum 86 series per patient before switching to `_scanN` suffix format
+- Does not anonymize other patient identifiers besides `AccessionNumber`
+
+## Related Projects
+
+This script is part of the `med_img_streamlit` repository, which also includes:
+- [dicom_anonymizer](../dicom_anonymizer/) - Interactive Streamlit web application for DICOM anonymization
+- [segmentation_checker](../segmentation_checker/) - MRI segmentation visualization tool
+
+## License
+
+Part of the medical imaging Streamlit applications repository.

--- a/dicom_anonymizer_2/anonymizer_rename.py
+++ b/dicom_anonymizer_2/anonymizer_rename.py
@@ -1,0 +1,453 @@
+"""
+DICOM X-Ray Anonymizer
+
+A standalone script that anonymizes X-Ray DICOM files by implementing a
+series-based Scan ID (PatientID+suffix) assigned to AccessionNumber field based
+on scan chronology per patient.
+
+Usage:
+    python anonymize_ngtcxr.py \
+        --input-dir /path/to/xray/data \
+        --output-csv-original /path/to/original_metadata.csv \
+        --output-csv-anon /path/to/anonymized_metadata.csv
+"""
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from pydicom import dcmread
+from pydicom.errors import InvalidDicomError
+from pydicom.tag import Tag
+
+
+# Define the DICOM tags to extract
+TAG_DICT = {
+    'PatientName':              Tag((0x0010, 0x0010)),
+    'PatientID':                Tag((0x0010, 0x0020)),
+    'PatientBirthDate':         Tag((0x0010, 0x0030)),
+    'PatientSex':               Tag((0x0010, 0x0040)),
+    'AccessionNumber':          Tag((0x0008, 0x0050)),
+    'InstitutionName':          Tag((0x0008, 0x0080)),
+    'StudyDate':                Tag((0x0008, 0x0020)),
+    'StudyTime':                Tag((0x0008, 0x0031)),
+    'SeriesInstanceUID':        Tag((0x0020, 0x000e)),
+    'BodyPartExamined':         Tag((0x0018, 0x0015))
+}
+
+
+# Suffix sequence for anonymization (printable ASCII table, excluding lowercase)
+# Starts with empty string, then uppercase letters (A-Z), then continues with
+# printable ASCII symbols and digits: !"#$%&'()*+,-./0-9:;<=>?@[\]^_`{|}~
+# Excludes lowercase letters a-z (ASCII 97-122)
+SUFFIXES = ['']
+# First: uppercase letters A-Z (ASCII 65-90)
+SUFFIXES += [chr(i) for i in range(ord('A'), ord('Z') + 1)]
+# Then: symbols and digits from ! to @ (ASCII 33-64, before uppercase letters)
+SUFFIXES += [chr(i) for i in range(33, 65)]
+# Then: symbols from [ to ` (ASCII 91-96, after uppercase letters, before lowercase)
+SUFFIXES += [chr(i) for i in range(91, 97)]
+# Finally: remaining symbols { | } ~ (ASCII 123-126, after lowercase letters)
+SUFFIXES += [chr(i) for i in range(123, 127)]
+
+
+def setup_logging(verbose: bool = False) -> None:
+    """Configure logging for the script."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+
+def discover_dicom_files(root_dir: str) -> list[Path]:
+    """
+    Discover all DICOM files in the root directory recursively.
+
+    Args:
+        root_dir: Root directory path to search for DICOM files
+
+    Returns:
+        List of Path objects for all .dcm files found
+    """
+    root_path = Path(root_dir)
+    if not root_path.is_dir():
+        raise ValueError(f"Input directory does not exist: {root_dir}")
+
+    logging.info(f"Searching for DICOM files in: {root_dir}")
+    dicom_files = list(root_path.rglob("*.dcm"))
+    logging.info(f"Found {len(dicom_files)} DICOM files")
+
+    return dicom_files
+
+
+def compute_output_path(file_path: Path, root_dir: Path, output_dir: Optional[Path] = None) -> Path:
+    """
+    Compute the output path for an anonymized DICOM file.
+
+    Args:
+        file_path: Original file path
+        root_dir: Original root directory
+        output_dir: Custom output directory (optional)
+
+    Returns:
+        Path for the anonymized file
+    """
+    if output_dir is None:
+        # Default: create sibling directory with "-Anonymized" suffix
+        output_base = root_dir.parent / f"{root_dir.name}-Anonymized"
+    else:
+        output_base = Path(output_dir)
+
+    # Maintain relative directory structure
+    relative_path = file_path.relative_to(root_dir)
+    return output_base / relative_path
+
+
+def extract_metadata(dicom_files: list[Path], root_dir: str, output_dir: Optional[Path] = None) -> pd.DataFrame:
+    """
+    Extract metadata from DICOM files into a DataFrame.
+
+    Args:
+        dicom_files: List of DICOM file paths
+        root_dir: Root directory path
+        output_dir: Custom output directory (optional)
+
+    Returns:
+        DataFrame with extracted metadata
+    """
+    root_path = Path(root_dir)
+
+    # Initialize data storage
+    data = {
+        'file_path': [],
+        'output_path': [],
+        **{tag_name: [] for tag_name in TAG_DICT.keys()}
+    }
+
+    failed_files = []
+    processed_count = 0
+
+    logging.info("Extracting metadata from DICOM files...")
+
+    for file_path in dicom_files:
+        try:
+            # Read DICOM file (stop before pixel data for efficiency)
+            dataset = dcmread(str(file_path), stop_before_pixels=True)
+
+            # Store paths
+            data['file_path'].append(str(file_path))
+            data['output_path'].append(str(compute_output_path(file_path, root_path, output_dir)))
+
+            # Extract DICOM tags
+            for tag_name in TAG_DICT.keys():
+                value = getattr(dataset, tag_name, None)
+
+                # Special handling for PatientName (PersonName objects)
+                if tag_name == 'PatientName' and value is not None:
+                    # Convert PersonName to string
+                    value = ''.join(str(value).split('^')) if value else ''
+
+                data[tag_name].append(value)
+
+            processed_count += 1
+
+            if processed_count % 100 == 0:
+                logging.debug(f"Processed {processed_count}/{len(dicom_files)} files")
+
+        except InvalidDicomError as e:
+            logging.warning(f"Invalid DICOM file: {file_path} - {e}")
+            failed_files.append(str(file_path))
+        except Exception as e:
+            logging.warning(f"Error processing file {file_path}: {e}")
+            failed_files.append(str(file_path))
+
+    logging.info(f"Successfully processed {processed_count}/{len(dicom_files)} files")
+    if failed_files:
+        logging.warning(f"Failed to process {len(failed_files)} files")
+
+    # Create DataFrame
+    df = pd.DataFrame(data)
+
+    return df
+
+
+def generate_anonymized_names(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Generate anonymized Scan IDs based on scan chronology per patient.
+
+    Logic:
+    1. Group by PatientID, then by unique SeriesInstanceUID to identify series
+    2. Sort series by StudyDate, then StudyTime (ascending)
+    3. First series: Scan ID = PatientID (no suffix)
+    4. Later series: Scan ID = PatientID + suffix (A, B, C, ...)
+    5. All files within the same series get the same Scan ID
+    6. Scan ID is assigned to AccessionNumber field
+
+    Args:
+        df: DataFrame with original metadata
+
+    Returns:
+        DataFrame with added 'Anonymized_PatientName' column (Scan ID)
+    """
+    logging.info("Generating anonymized Scan IDs (for AccessionNumber field)...")
+
+    # Make a copy to avoid SettingWithCopyWarning
+    df = df.copy()
+
+    # Handle missing StudyDate/StudyTime for sorting (treat as earliest)
+    df['StudyDate'] = df['StudyDate'].fillna('')
+    df['StudyTime'] = df['StudyTime'].fillna('')
+    # Handle missing SeriesInstanceUID
+    df['SeriesInstanceUID'] = df['SeriesInstanceUID'].fillna('')
+
+    # Group by PatientID
+    grouped = df.groupby('PatientID', dropna=False)
+
+    anonymized_names = []
+
+    for patient_id, group in grouped:
+        # Get unique series and sort them chronologically
+        unique_series = group.drop_duplicates(subset=['SeriesInstanceUID']).sort_values(
+            ['StudyDate', 'StudyTime'], ascending=True
+        )
+
+        # Create mapping from SeriesInstanceUID to suffix index
+        series_to_suffix = {}
+        for idx, (_, series_row) in enumerate(unique_series.iterrows()):
+            series_to_suffix[series_row['SeriesInstanceUID']] = idx
+
+        # Assign names to all files based on their series
+        for _, row in group.iterrows():
+            series_idx = series_to_suffix[row['SeriesInstanceUID']]
+
+            if series_idx == 0:
+                # First series: no suffix
+                new_name = str(patient_id) if pd.notna(patient_id) else ''
+            else:
+                # Later series: add suffix from ASCII table sequence
+                suffix = SUFFIXES[series_idx] if series_idx < len(SUFFIXES) else f"_scan{series_idx}"
+                new_name = f"{patient_id}{suffix}"
+
+            anonymized_names.append((row.name, new_name))
+
+    # Sort by original index to maintain DataFrame order
+    anonymized_names.sort(key=lambda x: x[0])
+
+    # Create the new column
+    df['Anonymized_PatientName'] = [name for _, name in anonymized_names]
+
+    # Log statistics
+    unique_patients = df['PatientID'].nunique()
+    logging.info(f"Generated anonymized names for {unique_patients} patients")
+
+    # Log anonymization details per patient
+    for patient_id, group in grouped:
+        # Count unique series (not total files)
+        unique_series_count = group.drop_duplicates(subset=['SeriesInstanceUID']).shape[0]
+        total_files = len(group)
+        first_name = group.iloc[0]['PatientName']
+        logging.debug(f"PatientID {patient_id}: {unique_series_count} series, {total_files} files, original name '{first_name}'")
+
+    return df
+
+
+def save_metadata_csv(df: pd.DataFrame, output_path: str, anonymized: bool = False) -> None:
+    """
+    Save metadata to a CSV file.
+
+    Args:
+        df: DataFrame with metadata
+        output_path: Path for output CSV file
+        anonymized: If True, save anonymized AccessionNumber; otherwise save original
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Select columns to save
+    if anonymized:
+        df_to_save = df.copy()
+        # Replace AccessionNumber with anonymized version
+        df_to_save['AccessionNumber'] = df_to_save['Anonymized_PatientName']
+        # Drop internal columns
+        columns_to_drop = ['file_path', 'output_path', 'Anonymized_PatientName']
+        df_to_save = df_to_save.drop(columns=[col for col in columns_to_drop if col in df_to_save.columns])
+    else:
+        # Drop internal columns
+        columns_to_drop = ['file_path', 'output_path', 'Anonymized_PatientName']
+        df_to_save = df.drop(columns=[col for col in columns_to_drop if col in df.columns])
+
+    df_to_save.to_csv(output_path, index=False)
+    logging.info(f"Saved {'anonymized' if anonymized else 'original'} metadata to: {output_path}")
+
+
+def anonymize_dicom_files(df: pd.DataFrame) -> None:
+    """
+    Anonymize DICOM files by modifying AccessionNumber and saving to output directory.
+
+    Args:
+        df: DataFrame with file paths and anonymized names
+    """
+    logging.info("Anonymizing DICOM files...")
+
+    success_count = 0
+    failed_count = 0
+
+    for idx, row in df.iterrows():
+        input_path = Path(row['file_path'])
+        output_path = Path(row['output_path'])
+        new_name = row['Anonymized_PatientName']
+
+        try:
+            # Read DICOM file
+            dataset = dcmread(str(input_path))
+
+            # Log before modification
+            original_accession = getattr(dataset, 'AccessionNumber', None)
+            logging.debug(f"File: {input_path.name}")
+            logging.debug(f"  Original AccessionNumber: {original_accession}")
+            logging.debug(f"  New AccessionNumber: {new_name}")
+
+            # Update AccessionNumber
+            dataset.AccessionNumber = str(new_name)
+
+            # Verify the change
+            logging.debug(f"  Verified AccessionNumber after update: {dataset.AccessionNumber}")
+
+            # Create output directory
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Save anonymized file
+            dataset.save_as(str(output_path))
+
+            # Verify saved file
+            verification_ds = dcmread(str(output_path))
+            logging.debug(f"  Saved file AccessionNumber: {verification_ds.AccessionNumber}")
+
+            success_count += 1
+
+            if success_count % 100 == 0:
+                logging.debug(f"Anonymized {success_count}/{len(df)} files")
+
+        except Exception as e:
+            logging.error(f"Failed to anonymize {input_path}: {e}")
+            import traceback
+            logging.error(traceback.format_exc())
+            failed_count += 1
+
+    logging.info(f"Anonymization complete: {success_count} successful, {failed_count} failed")
+
+
+def main():
+    """Main entry point for the script."""
+    parser = argparse.ArgumentParser(
+        description='Anonymize DICOM X-Ray files based on series chronology',
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        '--input-dir',
+        required=True,
+        help='Root directory containing DICOM files'
+    )
+
+    parser.add_argument(
+        '--output-csv-original',
+        required=True,
+        help='Path for original metadata CSV output'
+    )
+
+    parser.add_argument(
+        '--output-csv-anon',
+        required=True,
+        help='Path for anonymized metadata CSV output'
+    )
+
+    parser.add_argument(
+        '--output-dir',
+        default=None,
+        help='Custom output directory (default: <input-dir>-Anonymized)'
+    )
+
+    parser.add_argument(
+        '--csv-only',
+        action='store_true',
+        help='Only generate CSV files without modifying DICOM files'
+    )
+
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Enable verbose logging'
+    )
+
+    args = parser.parse_args()
+
+    # Setup logging
+    setup_logging(args.verbose)
+
+    logging.info("=" * 60)
+    logging.info("DICOM X-Ray Anonymizer")
+    logging.info("=" * 60)
+
+    try:
+        # Step 1: Discover DICOM files
+        dicom_files = discover_dicom_files(args.input_dir)
+        if not dicom_files:
+            logging.error("No DICOM files found. Exiting.")
+            return
+
+        # Step 2: Extract metadata
+        df = extract_metadata(dicom_files, args.input_dir, args.output_dir)
+
+        # Step 3: Save original metadata CSV
+        save_metadata_csv(df, args.output_csv_original, anonymized=False)
+
+        # Step 4: Generate anonymized names
+        df = generate_anonymized_names(df)
+
+        # Step 5: Save anonymized metadata CSV
+        save_metadata_csv(df, args.output_csv_anon, anonymized=True)
+
+        # Step 6: Anonymize DICOM files (skip if csv-only mode)
+        if not args.csv_only:
+            anonymize_dicom_files(df)
+        else:
+            logging.info("CSV-only mode: Skipping DICOM file modification")
+
+        # Print summary
+        logging.info("=" * 60)
+        logging.info("SUMMARY")
+        logging.info("=" * 60)
+        logging.info(f"Total DICOM files found: {len(dicom_files)}")
+        logging.info(f"Unique patients: {df['PatientID'].nunique()}")
+
+        if args.csv_only:
+            logging.info("Mode: CSV-only (no DICOM files modified)")
+        else:
+            logging.info(f"Files successfully anonymized: {len(df)}")
+
+        logging.info(f"Original metadata: {args.output_csv_original}")
+        logging.info(f"Anonymized metadata: {args.output_csv_anon}")
+
+        if not args.csv_only:
+            if args.output_dir:
+                logging.info(f"Anonymized files: {args.output_dir}")
+            else:
+                output_dir = Path(args.input_dir).parent / f"{Path(args.input_dir).name}-Anonymized"
+                logging.info(f"Anonymized files: {output_dir}")
+
+        logging.info("=" * 60)
+        logging.info("Anonymization complete!")
+        logging.info("=" * 60)
+
+    except Exception as e:
+        logging.error(f"An error occurred: {e}", exc_info=args.verbose)
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a new standalone command-line tool for anonymizing DICOM X-Ray files with series-based Scan ID assignment. This tool complements the existing Streamlit web application by providing a scriptable CLI option for batch processing workflows.

## What's New

- **New directory**: `dicom_anonymizer_2/` containing:
  - `anonymizer_rename.py`: Standalone Python script (~450 lines)
  - `README.md`: Comprehensive documentation with usage examples

## Key Features

- **Series-Based Anonymization**: Assigns unique Scan IDs to each series per patient based on chronological order
- **Chronological Ordering**: Sorts series by StudyDate and StudyTime for consistent ID assignment
- **Suffix System**: Uses PatientID + suffix scheme (P001, P001A, P001B, etc.)
  - First series: no suffix
  - Subsequent series: A-Z, then printable ASCII symbols (86 total suffixes)
- **Metadata Export**: Generates both original and anonymized metadata CSV files
- **CSV-Only Mode**: Option to preview anonymization without modifying DICOM files
- **Directory Structure Preservation**: Maintains relative paths in output directory

## Anonymization Logic

The tool assigns Scan IDs to the `AccessionNumber` field:
1. Groups files by PatientID
2. Identifies unique series via SeriesInstanceUID
3. Sorts series chronologically (StudyDate → StudyTime)
4. Assigns suffixes: first series = PatientID, second = PatientID + "A", etc.
5. All files in the same series receive the same Scan ID

### Example
| Series | StudyDate | Original AccessionNumber | New AccessionNumber |
|--------|-----------|-------------------------|---------------------|
| Series 1 | 2025-01-10 | ACC001 | `P001` |
| Series 2 | 2025-01-15 | ACC002 | `P001A` |
| Series 3 | 2025-01-20 | ACC003 | `P001B` |

## Usage

```bash
# Basic usage
python anonymizer_rename.py \
    --input-dir /path/to/xray/data \
    --output-csv-original original_metadata.csv \
    --output-csv-anon anonymized_metadata.csv

# CSV-only mode (no DICOM modification)
python anonymizer_rename.py \
    --input-dir /path/to/xray/data \
    --output-csv-original original.csv \
    --output-csv-anon anonymized.csv \
    --csv-only
